### PR TITLE
Removed the custom gutter font-size

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -9,7 +9,6 @@ atom-text-editor, :host {
   background-color: @syntax-gutter-background-color;
   color: @syntax-gutter-text-color;
   border-right: solid 1px @syntax-gutter-border-color;
-  font-size: 9px;
   font-weight: 100;
 }
 


### PR DESCRIPTION
It causes display issue in recent versions of Atom

**Before**

![before](https://cloud.githubusercontent.com/assets/31945/14591581/5ddb71b6-0557-11e6-944e-788360abc39d.png)

**After**

![after](https://cloud.githubusercontent.com/assets/31945/14591582/61dd8916-0557-11e6-8c06-71dfc93dad8c.png)
